### PR TITLE
Close quote and element on 'comment' assetField

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -27,7 +27,7 @@
                         <mibObj oid=".1.3.6.1.4.1.674.10892.5.1.1.8.0" alias="racFirmwareVersion"/>
                 </mibObjs>
         </assetField>
-        <assetField name="comment" formatString="&#xa;Service Tag:${systemServiceTag}&#xa;ServiceExpressCode:${systemExpressServiceCode}&#xa;Firmware:${racFirmwareVersion}
+        <assetField name="comment" formatString="&#xa;Service Tag:${systemServiceTag}&#xa;ServiceExpressCode:${systemExpressServiceCode}&#xa;Firmware:${racFirmwareVersion}">
                 <mibObjs>
                         <mibObj oid=".1.3.6.1.4.1.674.10892.5.1.1.8.0" alias="racFirmwareVersion"/>
                         <mibObj oid=".1.3.6.1.4.1.674.10892.5.1.3.2.0" alias="systemServiceTag"/>


### PR DESCRIPTION
The formatString's quote wasn't closed, and the element tag was missing a closing '>'.